### PR TITLE
feat(ci): support major version bumps via major/** and breaking/** br…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,7 @@ jobs:
   # develop: always a patch bump (1.2.3 → 1.2.4).
   # master:  branch-aware bump, based on the merged PR's source branch
   #          name (see tools/detect_bump_type.py + README "Versioning"):
+  #            major/**, breaking/**          -> major (1.2.3 → 2.0.0)
   #            feat/**, feature/**            -> minor (1.2.3 → 1.3.0)
   #            fix/**, bugfix/**, hotfix/**   -> patch (1.2.3 → 1.2.4)
   #            anything else / direct push    -> minor (safe default)
@@ -214,7 +215,9 @@ jobs:
             BUMP_TYPE=$(python tools/detect_bump_type.py "$MERGE_MSG")
             echo "Merge message: $MERGE_MSG"
             echo "Detected bump type: $BUMP_TYPE"
-            if [ "$BUMP_TYPE" = "patch" ]; then
+            if [ "$BUMP_TYPE" = "major" ]; then
+              NEW_VERSION=$(python tools/bump_version.py --major)
+            elif [ "$BUMP_TYPE" = "patch" ]; then
               NEW_VERSION=$(python tools/bump_version.py)
             else
               NEW_VERSION=$(python tools/bump_version.py --minor)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Branch-aware version bumping on `master`** — merging a `feat/**`/`feature/**` branch now bumps the minor version as before (`1.2.3` → `1.3.0`), but merging a `fix/**`/`bugfix/**`/`hotfix/**` branch now only bumps the patch version (`1.2.3` → `1.2.4`) instead of always jumping the minor version. Detection is based on the merged PR's source branch name and implemented in `tools/detect_bump_type.py` (fully unit-tested). See README "Versioning" for the full convention and fallback behaviour.
+- **Major version bumps now supported by tooling** — merging a `major/**`/`breaking/**` branch into `master` bumps the major version (`1.2.3` → `2.0.0`), resetting minor and patch to 0. Previously `MAJOR` could only be changed by hand-editing `config.py`. `tools/bump_version.py` gained a `--major` flag; `tools/detect_bump_type.py` recognises the new branch prefixes. See README "Versioning" for guidance on when to use it.
 
 ### Added
 - **Impressum links** — added a link to the developer's personal website (tombra.ddns.net) and an official "Buy Me a Coffee" button (buymeacoffee.com/tombra), both purely optional/supportive, clearly marked as free-to-use software.

--- a/README.md
+++ b/README.md
@@ -165,8 +165,7 @@ CI signing is automatic when the `CODE_SIGN_PFX_BASE64` and `CODE_SIGN_PASSWORD`
 
 ## Versioning
 
-Versions follow `MAJOR.MINOR.PATCH`. `MAJOR` is only ever bumped manually.
-`MINOR` and `PATCH` are bumped automatically by CI:
+Versions follow `MAJOR.MINOR.PATCH`.
 
 - **Pushes to `develop`** always bump the patch version (`1.2.3` → `1.2.4`).
 - **Merges into `master`** are bump-type-aware, based on the **name of the
@@ -174,6 +173,7 @@ Versions follow `MAJOR.MINOR.PATCH`. `MAJOR` is only ever bumped manually.
 
   | Branch prefix | Bump | Example |
   |---|---|---|
+  | `major/…`, `breaking/…` | **major** (`1.2.3` → `2.0.0`) | `major/v2-redesign` |
   | `feat/…`, `feature/…` | **minor** (`1.2.3` → `1.3.0`) | `feat/recipes` |
   | `fix/…`, `bugfix/…`, `hotfix/…` | **patch** (`1.2.3` → `1.2.4`) | `fix/installer-crash` |
   | anything else, or a direct push (no PR) | **minor** (safe default) | — |
@@ -181,8 +181,22 @@ Versions follow `MAJOR.MINOR.PATCH`. `MAJOR` is only ever bumped manually.
   Detection logic lives in `tools/detect_bump_type.py` (fully unit-tested,
   no GitHub Actions dependency). Squash-merged PRs lose the branch name in
   their commit message, so they also fall back to the minor-bump default —
-  prefer "Create a merge commit" for `master` PRs if you want patch bumps
-  to take effect.
+  prefer "Create a merge commit" for `master` PRs if you want patch or
+  major bumps to take effect.
+
+  **When to use `major/**` / `breaking/**`:** reserve this for changes that
+  are not safe for an existing installation to silently auto-update into —
+  a breaking database/config change, a removed feature, or a large-enough
+  UI/UX overhaul that users should be made aware of before updating (the
+  self-updater applies new versions automatically; a major bump is the
+  signal that "this one is different"). Since the auto-updater doesn't
+  currently gate on version jumps, treat the `major/**` prefix as a
+  deliberate, manual decision — name the feature/release branch
+  accordingly when you know ahead of time that the change qualifies, then
+  merge it into `master` via a regular PR merge commit as usual. There is
+  no separate manual step: `tools/bump_version.py --major` (also usable
+  standalone, e.g. `python tools/bump_version.py --major`) resets both
+  `MINOR` and `PATCH` to `0`, exactly like `--minor` resets `PATCH`.
 
 ---
 

--- a/tests/test_bump_version.py
+++ b/tests/test_bump_version.py
@@ -1,0 +1,112 @@
+"""
+Tests for tools/bump_version.py — patch/minor/major version bumping.
+"""
+from __future__ import annotations
+
+import textwrap
+
+from tools import bump_version
+
+
+def _write_config(tmp_path, version="1.2.3"):
+    cfg = tmp_path / "config.py"
+    cfg.write_text(
+        textwrap.dedent(f'''\
+            """Config."""
+            APP_NAME = "TireStorageManager"
+            VERSION = "{version}"
+            '''),
+        encoding="utf-8",
+    )
+    return cfg
+
+
+def _write_pyproject(tmp_path, version="1.2.3"):
+    pp = tmp_path / "pyproject.toml"
+    pp.write_text(
+        textwrap.dedent(f'''\
+            [project]
+            name = "tire-storage-manager"
+            version = "{version}"
+            '''),
+        encoding="utf-8",
+    )
+    return pp
+
+
+class TestBumpVersionMain:
+    def test_default_bump_is_patch(self, tmp_path, monkeypatch, capsys):
+        cfg = _write_config(tmp_path)
+        monkeypatch.setattr(bump_version, "CONFIG_PATH", cfg)
+        monkeypatch.setattr(bump_version, "CHANGELOG_PATH", tmp_path / "nope.md")
+        monkeypatch.setattr(bump_version, "PYPROJECT_PATH", tmp_path / "nope.toml")
+        monkeypatch.setattr("sys.argv", ["bump_version.py"])
+
+        rc = bump_version.main()
+
+        assert rc == 0
+        assert capsys.readouterr().out.strip() == "1.2.4"
+        assert 'VERSION = "1.2.4"' in cfg.read_text(encoding="utf-8")
+
+    def test_minor_bump_resets_patch(self, tmp_path, monkeypatch, capsys):
+        cfg = _write_config(tmp_path)
+        monkeypatch.setattr(bump_version, "CONFIG_PATH", cfg)
+        monkeypatch.setattr(bump_version, "CHANGELOG_PATH", tmp_path / "nope.md")
+        monkeypatch.setattr(bump_version, "PYPROJECT_PATH", tmp_path / "nope.toml")
+        monkeypatch.setattr("sys.argv", ["bump_version.py", "--minor"])
+
+        rc = bump_version.main()
+
+        assert rc == 0
+        assert capsys.readouterr().out.strip() == "1.3.0"
+        assert 'VERSION = "1.3.0"' in cfg.read_text(encoding="utf-8")
+
+    def test_major_bump_resets_minor_and_patch(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        cfg = _write_config(tmp_path)
+        monkeypatch.setattr(bump_version, "CONFIG_PATH", cfg)
+        monkeypatch.setattr(bump_version, "CHANGELOG_PATH", tmp_path / "nope.md")
+        monkeypatch.setattr(bump_version, "PYPROJECT_PATH", tmp_path / "nope.toml")
+        monkeypatch.setattr("sys.argv", ["bump_version.py", "--major"])
+
+        rc = bump_version.main()
+
+        assert rc == 0
+        assert capsys.readouterr().out.strip() == "2.0.0"
+        assert 'VERSION = "2.0.0"' in cfg.read_text(encoding="utf-8")
+
+    def test_major_bump_from_nonzero_minor_patch(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        cfg = _write_config(tmp_path, version="3.7.9")
+        monkeypatch.setattr(bump_version, "CONFIG_PATH", cfg)
+        monkeypatch.setattr(bump_version, "CHANGELOG_PATH", tmp_path / "nope.md")
+        monkeypatch.setattr(bump_version, "PYPROJECT_PATH", tmp_path / "nope.toml")
+        monkeypatch.setattr("sys.argv", ["bump_version.py", "--major"])
+
+        rc = bump_version.main()
+
+        assert rc == 0
+        assert capsys.readouterr().out.strip() == "4.0.0"
+
+    def test_major_bump_syncs_pyproject_version(self, tmp_path, monkeypatch):
+        cfg = _write_config(tmp_path)
+        pp = _write_pyproject(tmp_path)
+        monkeypatch.setattr(bump_version, "CONFIG_PATH", cfg)
+        monkeypatch.setattr(bump_version, "CHANGELOG_PATH", tmp_path / "nope.md")
+        monkeypatch.setattr(bump_version, "PYPROJECT_PATH", pp)
+        monkeypatch.setattr("sys.argv", ["bump_version.py", "--major"])
+
+        bump_version.main()
+
+        assert 'version = "2.0.0"' in pp.read_text(encoding="utf-8")
+
+    def test_missing_config_file_errors(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setattr(bump_version, "CONFIG_PATH", tmp_path / "nope.py")
+        monkeypatch.setattr("sys.argv", ["bump_version.py", "--major"])
+
+        rc = bump_version.main()
+
+        assert rc == 2
+        assert "not found" in capsys.readouterr().err

--- a/tests/test_detect_bump_type.py
+++ b/tests/test_detect_bump_type.py
@@ -71,6 +71,18 @@ class TestDetectBumpType:
         msg = "Merge pull request #6 from tombo92/feature/dark-mode"
         assert detect_bump_type(msg) == "minor"
 
+    def test_major_prefix_is_major(self):
+        msg = "Merge pull request #10 from tombo92/major/v2-redesign"
+        assert detect_bump_type(msg) == "major"
+
+    def test_breaking_prefix_is_major(self):
+        msg = "Merge pull request #11 from tombo92/breaking/new-db-schema"
+        assert detect_bump_type(msg) == "major"
+
+    def test_nested_major_path_is_major(self):
+        msg = "Merge pull request #12 from tombo92/major/ui/full-redesign"
+        assert detect_bump_type(msg) == "major"
+
     def test_unrecognized_prefix_defaults_to_minor(self):
         msg = "Merge pull request #7 from tombo92/improve-search-function"
         assert detect_bump_type(msg) == "minor"
@@ -92,12 +104,29 @@ class TestDetectBumpType:
         msg = "Merge pull request #8 from tombo92/Fix/typo"
         assert detect_bump_type(msg) == "minor"
 
+    def test_major_prefix_takes_precedence_over_fix_substring(self):
+        """A branch that merely contains 'fix' after 'major/' must still
+        be classified as major, not patch (prefix match, not substring)."""
+        msg = "Merge pull request #13 from tombo92/major/fix-everything"
+        assert detect_bump_type(msg) == "major"
+
 
 class TestMainCli:
     def test_prints_patch_for_bugfix_branch(self, capsys):
         rc = main(["Merge pull request #1 from tombo92/fix/crash"])
         assert rc == 0
         assert capsys.readouterr().out.strip() == "patch"
+
+    def test_prints_major_for_major_branch(self, capsys):
+        rc = main(["Merge pull request #2 from tombo92/major/v2-redesign"])
+        assert rc == 0
+        assert capsys.readouterr().out.strip() == "major"
+
+    def test_prints_major_for_breaking_branch(self, capsys):
+        rc = main(["Merge pull request #3 from tombo92/breaking/new-api"])
+        assert rc == 0
+        assert capsys.readouterr().out.strip() == "major"
+
 
     def test_prints_minor_for_feature_branch(self, capsys):
         rc = main(["Merge pull request #2 from tombo92/feat/recipes"])

--- a/tools/bump_version.py
+++ b/tools/bump_version.py
@@ -7,13 +7,17 @@
 Bump VERSION="x.y.z" in config.py.
 
 Versioning scheme:
-  x  – major: updated manually only
+  x  – major: bumped for breaking changes / big feature rollouts, via
+           the `major/**` or `breaking/**` branch-prefix convention on
+           master (see tools/detect_bump_type.py), or explicitly with
+           the --major flag. Resets minor and patch to 0.
   y  – minor: bumped on every push to master  (--minor flag, resets z to 0)
   z  – patch: bumped on every push to develop (default, no flag)
 
 Usage:
   python tools/bump_version.py           # patch bump:  1.2.3 → 1.2.4
   python tools/bump_version.py --minor   # minor bump:  1.2.3 → 1.3.0
+  python tools/bump_version.py --major   # major bump:  1.2.3 → 2.0.0
 """
 # ========================================================
 # IMPORTS
@@ -98,6 +102,11 @@ def main() -> int:
         "--minor", action="store_true",
         help="Bump minor version and reset patch to 0 (push to main)",
     )
+    parser.add_argument(
+        "--major", action="store_true",
+        help="Bump major version and reset minor+patch to 0 "
+             "(breaking changes / big feature rollouts)",
+    )
     args = parser.parse_args()
 
     if not CONFIG_PATH.exists():
@@ -113,7 +122,11 @@ def main() -> int:
     pre, major, minor, patch, post = m.groups()
     major, minor, patch = int(major), int(minor), int(patch)
 
-    if args.minor:
+    if args.major:
+        major += 1
+        minor = 0
+        patch = 0
+    elif args.minor:
         minor += 1
         patch = 0
     else:

--- a/tools/detect_bump_type.py
+++ b/tools/detect_bump_type.py
@@ -1,15 +1,22 @@
 #!/usr/bin/env python
 """
 detect_bump_type.py — decide whether a merge to master should bump the
-minor or patch version component, based on the merged branch's name.
+major, minor, or patch version component, based on the merged branch's
+name.
 
 Convention (see README.md "Versioning" section):
+    major/**, breaking/**          -> major bump   (x+1.0.0)
     feat/**, feature/**            -> minor bump   (x.y+1.0)
     fix/**, bugfix/**, hotfix/**   -> patch bump   (x.y.z+1)
     anything else / no PR merge    -> minor bump   (safe default —
                                        matches the behaviour that existed
                                        before this branch-aware detection
                                        was introduced)
+
+Use the `major/**` or `breaking/**` prefix deliberately and sparingly —
+for breaking changes, a major UI overhaul, or any release that isn't
+safe to auto-update into without the user's attention. A major bump
+resets both MINOR and PATCH to 0.
 
 Branch detection relies on GitHub's default "Create a merge commit" PR
 merge strategy, whose first commit line looks like::
@@ -21,7 +28,7 @@ detection falls back to "minor" (the previous, always-minor behaviour).
 
 Usage (CI):
     python tools/detect_bump_type.py "$(git log -1 --format=%s)"
-    -> prints "minor" or "patch" to stdout
+    -> prints "major", "minor", or "patch" to stdout
 """
 from __future__ import annotations
 
@@ -30,6 +37,7 @@ import sys
 
 _MERGE_RX = re.compile(r"^Merge pull request #\d+ from [^/\s]+/(\S+)\s*$")
 
+_MAJOR_PREFIXES = ("major/", "breaking/")
 _PATCH_PREFIXES = ("fix/", "bugfix/", "hotfix/")
 _MINOR_PREFIXES = ("feat/", "feature/")
 
@@ -50,14 +58,18 @@ def extract_branch_name(commit_message: str) -> str | None:
 
 
 def detect_bump_type(commit_message: str) -> str:
-    """Return ``"minor"`` or ``"patch"`` for a master merge commit message."""
+    """Return ``"major"``, ``"minor"``, or ``"patch"`` for a master merge
+    commit message."""
     branch = extract_branch_name(commit_message)
     if branch is None:
         return "minor"  # not a recognised PR merge — safe default
+    if branch.startswith(_MAJOR_PREFIXES):
+        return "major"
     if branch.startswith(_PATCH_PREFIXES):
         return "patch"
     # _MINOR_PREFIXES and any unrecognised prefix both fall through here —
-    # minor is the safe default when we can't positively identify a bugfix.
+    # minor is the safe default when we can't positively identify a bugfix
+    # or breaking change.
     return "minor"
 
 


### PR DESCRIPTION
…anches

MAJOR could previously only be changed by hand-editing config.py. Now merging a major/** or breaking/** branch into master bumps the major version (1.2.3 -> 2.0.0), resetting minor and patch to 0 — symmetric with the existing feat/**->minor and fix/**->patch detection.

- tools/bump_version.py: new --major flag
- tools/detect_bump_type.py: recognise major/**, breaking/** prefixes (checked before the patch prefixes so e.g. major/fix-everything is still classified as major, not patch)
- .github/workflows/ci.yml: bump step handles the three-way branch
- README: document the convention and when to use it (breaking changes, non-auto-updatable changes, big UI/UX overhauls)
- 20 new/updated tests covering detection, CLI output, and the version-file mutation itself (including pyproject.toml sync)